### PR TITLE
Fix: Update Output Plugin Handling for Stability & Add Bulk Size Configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.12.4-slim-bullseye AS base
+FROM python:3.12-slim-bookworm AS base
 
 # Install dependencies using apt-get
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -13,25 +13,32 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssl \
     libssl-dev \
     gdb \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Define build argument for architecture
 ARG TARGETARCH
 
-# Set the plugin URL based on the architecture
-ENV LOGZIO_PLUGIN_URL_AMD64=https://github.com/logzio/fluent-bit-logzio-output/raw/master/build/out_logzio-linux.so
-ENV LOGZIO_PLUGIN_URL_ARM64=https://github.com/logzio/fluent-bit-logzio-output/raw/master/build/out_logzio-linux-arm64.so
+# Define the base URL for your plugin's GitHub releases
+ENV GITHUB_REPO_URL=https://github.com/logzio/fluent-bit-logzio-output
+# Define the specific asset names as they appear in your GitHub Release
+ENV LOGZIO_PLUGIN_ASSET_AMD64=out_logzio-linux-amd64.so
+ENV LOGZIO_PLUGIN_ASSET_ARM64=out_logzio-linux-arm64.so
 
-# Determine the correct plugin URL based on TARGETARCH
+# Determine the correct plugin URL and download
 RUN mkdir -p /fluent-bit/plugins && \
+    PLUGIN_DOWNLOAD_URL="" && \
     if [ "$TARGETARCH" = "amd64" ]; then \
-        export LOGZIO_PLUGIN_URL=$LOGZIO_PLUGIN_URL_AMD64; \
+        PLUGIN_DOWNLOAD_URL="${GITHUB_REPO_URL}/releases/latest/download/${LOGZIO_PLUGIN_ASSET_AMD64}"; \
     elif [ "$TARGETARCH" = "arm64" ]; then \
-        export LOGZIO_PLUGIN_URL=$LOGZIO_PLUGIN_URL_ARM64; \
+        PLUGIN_DOWNLOAD_URL="${GITHUB_REPO_URL}/releases/latest/download/${LOGZIO_PLUGIN_ASSET_ARM64}"; \
     else \
         echo "Unsupported architecture: $TARGETARCH"; exit 1; \
     fi && \
-    wget -O /fluent-bit/plugins/out_logzio.so $LOGZIO_PLUGIN_URL
+    echo "Downloading plugin from: $PLUGIN_DOWNLOAD_URL" && \
+    # Using curl -L to follow redirects (important for /latest/) and -o to output to file
+    curl -fsSL -o /fluent-bit/plugins/out_logzio.so "$PLUGIN_DOWNLOAD_URL" && \
+    if [ ! -s /fluent-bit/plugins/out_logzio.so ]; then echo "Error: Downloaded plugin is empty or failed."; exit 1; fi
 
 # Set working directory
 WORKDIR /opt/fluent-bit
@@ -44,7 +51,7 @@ COPY docker-metadata.lua /fluent-bit/etc/docker-metadata.lua
 COPY create_fluent_bit_config.py /opt/fluent-bit/docker-collector-logs/create_fluent_bit_config.py
 
 # Use official Fluent Bit image for Fluent Bit binaries
-FROM fluent/fluent-bit:1.9.10 AS fluent-bit
+FROM fluent/fluent-bit:3.2.2 AS fluent-bit
 
 # Copy Fluent Bit binary to the base image
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM python:3.12-slim-bookworm AS base
 
 # Install dependencies using apt-get
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    wget \
     bash \
     libyaml-dev \
     libsystemd-dev \

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ logzio/docker-logs-collector:latest
 | **LOGZIO_LOGS_TOKEN**          | **Required**. Your Logz.io account logs token. Replace `<LOGS-SHIPPING-TOKEN>` with the [token](https://app.logz.io/#/dashboard/settings/general) of the account you want to ship to.                                                                                                                  |
 | **LOGZIO_URL**                 | **Default**: `https://listener.logz.io:8071`.<br> The full URL to send logs to, including your region if needed. For example, for the EU region, use `https://listener-eu.logz.io:8071`. to.                                                                                                           |
 | **LOGZIO_TYPE**                | **Default**: `logzio-docker-logs`. Sets the log type.                                                                                                                                                                                                                                                  |
-| **LOGS_PATH**                  | **Dfault**: `/var/lib/docker/containers/*/*.log`. The path to docker container logs, supports globs                                                                                                                                                                                                    |
+| **LOGZIO_BULK_SIZE_MB** | **Optional**. Max uncompressed log bulk size (MB) before flush. Plugin default: `2`. Valid: `1`-`9`. Affects memory/performance. |
+| **LOGS_PATH**                  | **Default**: `/var/lib/docker/containers/*/*.log`. The path to docker container logs, supports globs                                                                                                                                                                                                    |
 | **MATCH_CONTAINER_NAME**       | Specify a container to collect logs from. If the container's name matches, its logs are shipped; otherwise, its logs are ignored. <br /> **Note**: This option cannot be used with SKIP_CONTAINER_NAMES. Use regular expressions to keep records that match a specific field.                          |
 | **SKIP_CONTAINER_NAMES**       | Comma-separated list of containers to ignore. If a container's name matches a name on this list, its logs are ignored; otherwise, its logs are shipped. <br /> **Note**: This option cannot be used with MATCH_CONTAINER_NAME. Use regular expressions to exclude records that match a specific field. |
 | **MATCH_IMAGE_NAME**           | Specify a image to collect logs from. If the image's name matches, its logs are shipped; otherwise, its logs are ignored. <br /> **Note**: This option cannot be used with SKIP_IMAGE_NAMES. Use regular expressions to keep records that match a specific field.                                      |
@@ -64,6 +65,10 @@ logzio/docker-logs-collector:latest
 Spin up your Docker containers if you haven’t done so already. Give your logs a few minutes to get from your system to your Logz.io account.
 
 ### Change log
+- 0.1.2:
+  - Updated internal `fluent-bit-logzio-output` plugin to its latest stable release.
+  - Added `LOGZIO_BULK_SIZE_MB` environment variable to configure the output plugin's batch size.  
+  - Upgraded base image to Debian Bookworm.
 - 0.1.1:
   - Add `LOGS_PATH` option.
 - 0.1.0:

--- a/create_fluent_bit_config.py
+++ b/create_fluent_bit_config.py
@@ -29,6 +29,7 @@ class Config:
         self.multiline_start_state_rule = os.getenv('MULTILINE_START_STATE_RULE', '')
         self.multiline_custom_rules = os.getenv('MULTILINE_CUSTOM_RULES', '')
         self.logs_path = os.getenv('LOGS_PATH', '/var/lib/docker/containers/*/*.log')
+        self.logzio_bulk_size_mb = os.getenv('LOGZIO_BULK_SIZE_MB', '')
 
 
 def create_fluent_bit_config(config):
@@ -217,6 +218,10 @@ def _get_output_config(config):
 """
     if config.headers:
         output_config += f"    headers      {config.headers}\n"
+    
+    if config.logzio_bulk_size_mb:
+        output_config += f"    logzio_bulk_size_mb {config.logzio_bulk_size_mb}\n"
+
     return output_config
 
 

--- a/tests/test_create_fluent_bit_config.py
+++ b/tests/test_create_fluent_bit_config.py
@@ -41,6 +41,7 @@ class TestCreateFluentBitConfig(unittest.TestCase):
         self.assertIn('[INPUT]', config)
         self.assertIn('Name         tail', config)
         self.assertNotIn('multiline.parser', config)
+        self.assertNotIn('logzio_bulk_size_mb', config)
 
     @patch.dict(os.environ, {
         'LOGZIO_LOGS_TOKEN': 'test_token',
@@ -223,6 +224,28 @@ class TestCreateFluentBitConfig(unittest.TestCase):
 
             # Since MULTILINE_START_STATE_RULE is not set, multiline config should not be created
             mock_create_multiline_config.assert_not_called()
+
+    @patch.dict(os.environ, {
+        'LOGZIO_LOGS_TOKEN': 'test_token',
+        'LOGZIO_BULK_SIZE_MB': '5' 
+    })
+    def test_logzio_bulk_size_mb_configured(self):
+        config_obj = create_fluent_bit_config.Config()
+        self.assertEqual(config_obj.logzio_bulk_size_mb, '5')
+        
+        config_str = create_fluent_bit_config.create_fluent_bit_config(config_obj)
+        self.assertIn('logzio_bulk_size_mb 5', config_str)
+
+    @patch.dict(os.environ, {
+        'LOGZIO_LOGS_TOKEN': 'test_token',
+        'LOGZIO_BULK_SIZE_MB': '' 
+    })
+    def test_logzio_bulk_size_mb_empty_env_var(self):
+        config_obj = create_fluent_bit_config.Config()
+        self.assertEqual(config_obj.logzio_bulk_size_mb, '')
+
+        config_str = create_fluent_bit_config.create_fluent_bit_config(config_obj)
+        self.assertNotIn('logzio_bulk_size_mb', config_str)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes crashes in the `docker-logs-collector` by:
1.  Updating the `Dockerfile` to fetch the `fluent-bit-logzio-output` plugin from its latest GitHub Release assets instead of from the `master` branch build artifacts.
2.  Upgrading the base Docker image to `python:3.12-slim-bookworm` to resolve GLIBC compatibility issues with the newer plugin.
3.  Adding a `LOGZIO_BULK_SIZE_MB` environment variable to allow users to configure the output plugin's internal batching size via the Python configuration script.
4.  Removing the previously committed `build/` directory, as binaries are now sourced from releases.

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [X] 🧑‍💻 Code Refactor (minor, in Dockerfile download method)
- [ ] 🔥 Performance Improvements
- [X] ✅ Test (Python unit tests were updated for the new env var)
- [ ] 🤖 Build / CI (Dockerfile changes build process)
- [ ] ⏩ Revert

## Added tests?

- [X] 👍 yes (Python unit tests were updated to cover the new environment variable)
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody